### PR TITLE
Update docs for 'update' event.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -225,7 +225,7 @@ Get a property.
 
 Set a property.
 
-#### on('update', function (key, value, source))
+#### on('update', function (change, timestamp, source))
 
 Emmitted when a property changes. 
 If `source !== this.id`


### PR DESCRIPTION
It looks like this api has changed. The call is done with:

``` js
this.emit.apply(this, ['update'].concat(update))
```
