### PR TITLE
remove duplicate declaration

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,8 +28,6 @@ function validate (data) {
   return true
 }
 
-var emit = EventEmitter.prototype.emit
-
 inherits (Scuttlebutt, EventEmitter)
 
 function Scuttlebutt (opts) {


### PR DESCRIPTION
why are you even writing `emit.call(this, ...)` instead of `this.emit(...)`?

edit: instead of `this.setMaxListeners(Number.MAX_VALUE)`, you could use `this.setMaxListeners(0)` for unlimited listeners, although your solution is technically more robust
