### PR TITLE
fix a bug with variable 'sources' getting an undefined value

### DIFF
--- a/index.js
+++ b/index.js
@@ -140,7 +140,10 @@ sb.createStream = function (opts) {
     //when the digest is recieved from the other end,
     //send the history.
     //merge with the current list of sources.
-    if (!data || !data.clock) return d._end()
+    if (!data || !data.clock) {
+        d.emit('error');
+        return d._end()
+    }
 
     sources = data.clock
 


### PR DESCRIPTION
We just moved to the latest seaport that uses scuttlebutt in prodution at Browserling and seaport started crashing in a repeated loop:

```
/home/ec2-user/projects/browserling-seaport-fix/bouncer/node_modules/seaport/node_modules/crdt/node_modules/scuttlebutt/index.js:212
    sources[source] = ts
                    ^
TypeError: Cannot set property '58C75509F2D2444F74A4AC93' of undefined
    at Doc.onUpdate (/home/ec2-user/projects/browserling-seaport-fix/bouncer/node_modules/seaport/node_modules/crdt/node_modules/scuttlebutt/index.js:212:21)
    at Doc.EventEmitter.emit (events.js:115:20)
    at Doc.applyUpdate (/home/ec2-user/projects/browserling-seaport-fix/bouncer/node_modules/seaport/node_modules/crdt/doc.js:218:8)
    at didVerification (/home/ec2-user/projects/browserling-seaport-fix/bouncer/node_modules/seaport/node_modules/crdt/node_modules/scuttlebutt/index.js:97:13)
    at Doc.sb._update (/home/ec2-user/projects/browserling-seaport-fix/bouncer/node_modules/seaport/node_modules/crdt/node_modules/scuttlebutt/index.js:111:5)
    at Doc.sb.localUpdate (/home/ec2-user/projects/browserling-seaport-fix/bouncer/node_modules/seaport/node_modules/crdt/node_modules/scuttlebutt/index.js:58:8)
    at Row.track (/home/ec2-user/projects/browserling-seaport-fix/bouncer/node_modules/seaport/node_modules/crdt/doc.js:93:9)
    at Row.EventEmitter.emit (events.js:91:17)
    at Row._set (/home/ec2-user/projects/browserling-seaport-fix/bouncer/node_modules/seaport/node_modules/crdt/row.js:47:8)
    at Row.set (/home/ec2-user/projects/browserling-seaport-fix/bouncer/node_modules/seaport/node_modules/crdt/row.js:30:8)
Forever detected script exited with code: 1
Forever restarting script for 24 time
```

This patch fixes this problem. Thank you!
