### PR TITLE
Fix confidant -> confident

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -295,7 +295,7 @@ var m = new Model(security(keys, PRIVATE, PUBLIC))
 ## Security API
 
 When security is enabled, each scuttlebutt message is signed with a private key.
-It is then possible for any scuttlebutt instance to be confidant about the
+It is then possible for any scuttlebutt instance to be confident about the
 authenticity of the message by verifying it against the source's public key.
 
 This is possible even if the verifying node received the message from an intermediate node.


### PR DESCRIPTION
Just a single letter fix in the README.

confidant: 

> noun
> a person with whom one shares a secret or private matter, trusting them not to repeat it to others.
> "a close confidante of the princess"
> synonyms: close friend, bosom friend, best friend, close associate, companion, crony, intimate, familiar, second self

confident: 

> adjective
> 1. feeling or showing confidence in oneself or one's abilities or qualities.
> "she was a confident, outgoing girl"
> synonyms: self-assured, assured, sure of oneself, self-confident, positive; More
> 2. feeling or showing certainty about something.
> "this time they're confident of a happy ending"
> synonyms: optimistic, hopeful, sanguine